### PR TITLE
fix bug: when ram start addr is not 0x0 the gp may be have wrong value

### DIFF
--- a/rt-thread/bsp/picorv32_blink/CMakeLists.txt
+++ b/rt-thread/bsp/picorv32_blink/CMakeLists.txt
@@ -5,22 +5,11 @@ set(CMAKE_SYSTEM_NAME Generic)
 set(CMAKE_SYSTEM_PROCESSOR riscv)
 SET(CMAKE_CROSSCOMPILING 1)
 
-set(tools /opt/riscv32i)
 set(LINKR_FILE ../drivers/linker_scripts/link.lds)
-set(CMAKE_ASM_COMPILER ${tools}/bin/riscv32-unknown-elf-gcc)
-set(CMAKE_C_COMPILER ${tools}/bin/riscv32-unknown-elf-gcc)
-set(CMAKE_CXX_COMPILER ${tools}/bin/riscv32-unknown-elf-g++)
-set(CMAKE_OBJCOPY ${tools}/bin/riscv32-unknown-elf-objcopy)
-set(CMAKE_OBJDUMP ${tools}/bin/riscv32-unknown-elf-objdump)
 
-set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
-set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
-set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
-set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
+set(CMAKE_C_FLAGS "-MD -Os -Wall -march=rv32im -mabi=ilp32" )
 
-set(CMAKE_C_FLAGS "-MD -Os -Wall" )
-
-set(CMAKE_ASM_FLAGS "-nostdlib" )
+set(CMAKE_ASM_FLAGS "-nostdlib -march=rv32im -mabi=ilp32" )
 set(LD_FLAGS "-ffunction-sections  -nostartfiles -Wl,--gc-sections")
 
 set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
@@ -67,6 +56,11 @@ set(RISCV_SRC
 set(CMAKE_SHARED_LIBRARY_LINK_C_FLAGS "")
 set(CMAKE_SHARED_LIBRARY_LINK_CXX_FLAGS "")
 
+set(HAVE_FLAG_SEARCH_PATHS_FIRST 0)
+set(CMAKE_ASM_LINK_FLAGS "")
+set(CMAKE_C_LINK_FLAGS "")
+set(CMAKE_CXX_LINK_FLAGS "")
+
 project (${PROJECT_NAME})
 
 include_directories(../../libcpu/risc-v/picorv32
@@ -77,16 +71,18 @@ include_directories(../../libcpu/risc-v/picorv32
 
 add_executable(${PROJECT_NAME}.elf ${RISCV_SRC})
 
-target_link_libraries(${PROJECT_NAME}.elf PRIVATE  -T${LINKR_FILE} ${LD_FLAGS},-Map=${MAP_TARGET})
+target_link_libraries(${PROJECT_NAME}.elf PRIVATE  -T${LINKR_FILE} ${LD_FLAGS},-Map=${MAP_TARGET},--print-memory-usage)
 
+if (NOT APPLE)
 # Remove option -rdynamic which is a bug
 add_custom_command(TARGET ${PROJECT_NAME}.elf PRE_BUILD
         COMMAND sed -i 's/-rdynamic//g' CMakeFiles/${PROJECT_NAME}.elf.dir/link.txt
 )
+endif()
 
 add_custom_command(TARGET ${PROJECT_NAME}.elf POST_BUILD
-        COMMAND ${CMAKE_OBJCOPY} -Obinary ${PROJECT_NAME}.elf ${BIN_TARGET}
+        COMMAND ${CMAKE_OBJCOPY} -O binary ${PROJECT_NAME}.elf ${BIN_TARGET}
         COMMAND ${CMAKE_OBJCOPY} -O verilog ${PROJECT_NAME}.elf ${TMP_TARGET}
-        COMMAND ${CMAKE_OBJDUMP} -S ${PROJECT_NAME}.elf > ${LSS_TARGET}
+        COMMAND ${CMAKE_OBJDUMP} -S -D -x ${PROJECT_NAME}.elf > ${LSS_TARGET}
         COMMENT "Generating ${HEX_TARGET}, ${BIN_TARGET}"
 )

--- a/rt-thread/bsp/picorv32_blink/drivers/board.c
+++ b/rt-thread/bsp/picorv32_blink/drivers/board.c
@@ -11,11 +11,8 @@
 #include <stdint.h>
 #include <rthw.h>
 #include <rtthread.h>
+#include "board.h"
 
-#define  TIMER_IRQ_VECTOR   0 
-#define  ECALL_IRQ_VECTOR   1 
-#define  SYSTEM_BUS_VECTOR  2 
-#define  SYSTEM_CORE_CLOCK 10000000l   //  10 MHZ  
 // Holds the system core clock, which is the system clock 
 // frequency supplied to the SysTick timer and the processor 
 // core clock.
@@ -50,6 +47,24 @@ void riscv_timer_handler(int vector, void *param)
 void riscv_ecall_handler(int vector, void *param)
 {
 
+}
+
+void rt_hw_console_output(const char *str)
+{
+    int i = 0;
+    for(i = 0; '\0' != str[i]; i++)
+    {
+        if(str[i] == '\n')
+        {
+            reg_uart_data = '\r';
+        }
+        reg_uart_data = str[i];
+    }
+}
+
+char rt_hw_console_getchar(void)
+{
+    return (char)(reg_uart_data & 0xff);
 }
 
 /**

--- a/rt-thread/bsp/picorv32_blink/drivers/board.h
+++ b/rt-thread/bsp/picorv32_blink/drivers/board.h
@@ -1,11 +1,13 @@
+
+
 #ifndef __BOARD_H__
 #define __BOARD_H__
 
 #define  TIMER_IRQ_VECTOR   0
 #define  ECALL_IRQ_VECTOR   1
 #define  SYSTEM_BUS_VECTOR  2
-#define  SYSTEM_CORE_CLOCK 10000000l   //  10 MHZ
+#define  SYSTEM_CORE_CLOCK 40500000l   //  40.5 MHZ
 
-#define reg_uart_data (*(volatile rt_uint32_t*)0x02000008)
+#define reg_uart_data (*(volatile rt_uint32_t*)0x083000000)
 
 #endif

--- a/rt-thread/bsp/picorv32_blink/drivers/board.h
+++ b/rt-thread/bsp/picorv32_blink/drivers/board.h
@@ -1,0 +1,11 @@
+#ifndef __BOARD_H__
+#define __BOARD_H__
+
+#define  TIMER_IRQ_VECTOR   0
+#define  ECALL_IRQ_VECTOR   1
+#define  SYSTEM_BUS_VECTOR  2
+#define  SYSTEM_CORE_CLOCK 10000000l   //  10 MHZ
+
+#define reg_uart_data (*(volatile rt_uint32_t*)0x02000008)
+
+#endif

--- a/rt-thread/bsp/picorv32_blink/drivers/linker_scripts/link.lds
+++ b/rt-thread/bsp/picorv32_blink/drivers/linker_scripts/link.lds
@@ -8,23 +8,23 @@ means.
 */
 
 /* starting address needs to be > 0 due to known bug in RISCV/GNU linker */
-MEMORY 
+MEMORY
 {
-  rom(rx)  : ORIGIN = 0x00020000, LENGTH = 32k
-  ram(rwx) : ORIGIN = 0x00000000, LENGTH = 16k
+  rom(rx)  : ORIGIN = 0x00000000, LENGTH = 32k
+  ram(rwx) : ORIGIN = 0x40000000, LENGTH = 16k
 }
 
 ENTRY(_pvstart);
 
-SECTIONS 
+SECTIONS
 {
-  .init :
+  .init 0x0:
   {
     . = ALIGN(4);
     *(.text.entry);
   } > rom
 
-  .interrupt 0x20400: 
+  .interrupt 0x400:
   {
     . = ALIGN(4);
     KEEP(*(.text.interrupt));
@@ -41,7 +41,7 @@ SECTIONS
       . = ALIGN(4);
     _edata = .;
   } >ram AT > rom
-  
+
   .bss :
   {
     _bss_start = .;
@@ -51,7 +51,7 @@ SECTIONS
     _bss_end = .;
     _end = .;
   } > ram
-  
+
   .rom :
   {
     . = ALIGN(4);
@@ -66,7 +66,7 @@ SECTIONS
     __vsymtab_start = .;
     KEEP(*(VSymTab))
     __vsymtab_end = .;
-    . = ALIGN(4);	
+    . = ALIGN(4);
     *(.stub .text.* .gnu.linkonce.t.*);
     *(.rodata  .rodata.*);
     *(.*);
@@ -74,8 +74,8 @@ SECTIONS
 
   .stack ORIGIN(ram) + LENGTH(ram) :
   {
-    _riscv_sp = . ; 
-  } > ram 
+    _riscv_sp = . ;
+  } > ram
 }
 
 

--- a/rt-thread/bsp/picorv32_blink/libraries/start.S
+++ b/rt-thread/bsp/picorv32_blink/libraries/start.S
@@ -67,9 +67,13 @@ _pvstart:
 
 
 _start:
+.option push
+.option norelax
 # Initialize global pointer
 1:  auipc gp, %pcrel_hi(__global_pointer$)
     addi  gp, gp, %pcrel_lo(1b)
+.option pop
+
 # Clear the bss segment
     la      a0, _edata
     la      a1, _end

--- a/rt-thread/bsp/picorv32_blink/porting-guide.txt
+++ b/rt-thread/bsp/picorv32_blink/porting-guide.txt
@@ -1,0 +1,4 @@
+1. Change the hard-coding config value in drivers/board.h.
+2. Change the implementation of rt_hw_console_getchar/rt_hw_console_output if necessary.
+3. Change the memory layout and the interrupt handler location in drivers/linker_scripts/link.lds.
+4. Add -march=rv32i or -march=rv32im in both CMAKE_C_FLAGS/CMAKE_ASM_FLAGS if necessary.

--- a/rt-thread/bsp/picorv32_blink/rtconfig.h
+++ b/rt-thread/bsp/picorv32_blink/rtconfig.h
@@ -7,15 +7,6 @@
 
 #define RT_USING_FINSH
 
-#if defined(__CC_ARM) || defined(__CLANG_ARM)
-#include "RTE_Components.h"
-
-#if defined(RTE_USING_FINSH)
-#define RT_USING_FINSH
-#endif //RTE_USING_FINSH
-
-#endif //(__CC_ARM) || (__CLANG_ARM)
-
 // <<< Use Configuration Wizard in Context Menu >>>
 // <h>Basic Configuration
 // <o>Maximal level of thread priority <8-256>
@@ -46,14 +37,14 @@
 // <h>Debug Configuration
 // <c1>enable kernel debug configuration
 //  <i>Default: enable kernel debug configuration
-//#define RT_DEBUG
+#define RT_DEBUG
 // </c>
 // <o>enable components initialization debug configuration<0-1>
 //  <i>Default: 0
 #define RT_DEBUG_INIT 0
 // <c1>thread stack over flow detect
 //  <i> Diable Thread stack over flow detect
-//#define RT_USING_OVERFLOW_CHECK
+#define RT_USING_OVERFLOW_CHECK
 // </c>
 // </h>
 
@@ -143,7 +134,7 @@
     // <o>the stack of finsh thread <1-4096>
     //  <i>the stack of finsh thread
     //  <i>Default: 4096  (4096Byte)
-    #define FINSH_THREAD_STACK_SIZE     512
+    #define FINSH_THREAD_STACK_SIZE     4096
     // <o>the history lines of finsh thread <1-32>
     //  <i>the history lines of finsh thread
     //  <i>Default: 5

--- a/rt-thread/bsp/picorv32_blink/toolchain-file.txt
+++ b/rt-thread/bsp/picorv32_blink/toolchain-file.txt
@@ -1,0 +1,15 @@
+set(tools /Users/besto/Source/xpack-riscv-none-elf-gcc-13.3.0-1/)
+set(CMAKE_ASM_COMPILER ${tools}/bin/riscv-none-elf-gcc)
+set(CMAKE_C_COMPILER ${tools}/bin/riscv-none-elf-gcc)
+set(CMAKE_CXX_COMPILER ${tools}/bin/riscv-none-elf-g++)
+set(CMAKE_OBJCOPY ${tools}/bin/riscv-none-elf-objcopy)
+set(CMAKE_OBJDUMP ${tools}/bin/riscv-none-elf-objdump)
+
+set(CMAKE_C_COMPILER_TARGET riscv-none-elf)
+set(CMAKE_CXX_COMPILER_TARGET riscv-none-elf)
+set(CMAKE_ASM_COMPILER_TARGET riscv-none-elf)
+
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)

--- a/rt-thread/libcpu/risc-v/picorv32/cpuport.c
+++ b/rt-thread/libcpu/risc-v/picorv32/cpuport.c
@@ -145,26 +145,6 @@ void rt_hw_interrupt_enable(rt_base_t level)
     return;
 }
 
-#define reg_uart_data (*(volatile rt_uint32_t*)0x02000008)
-
-void rt_hw_console_output(const char *str)
-{
-    int i=0;
-    for(i=0;'\0' != str[i];i++)
-    {
-        if(str[i] == '\n')
-        {
-            reg_uart_data = '\r';
-        }
-        reg_uart_data = str[i];
-    }
-}
-
-char rt_hw_console_getchar(void)
-{
-    return (char)((*(volatile int*)0x02000008)&0xFF);
-}
-
 /** shutdown CPU */
 void rt_hw_cpu_shutdown()
 {


### PR DESCRIPTION
在加载 gp 指针的时候，需要关闭松弛链接，不然gp加载的位置可能出错。
